### PR TITLE
Remove unnecessary instructions when narrowing char vectors to bytes

### DIFF
--- a/FlameCsv.Core/Reading/Internal/ISimdVector.Generated.cs
+++ b/FlameCsv.Core/Reading/Internal/ISimdVector.Generated.cs
@@ -170,24 +170,24 @@ internal readonly struct Vec128Char : ISimdVector<char, Vec128Char>
     {
         var v0 = Vector128.LoadUnsafe(ref Unsafe.As<char, ushort>(ref Unsafe.AsRef(in source)), offset);
         var v1 = Vector128.LoadUnsafe(ref Unsafe.As<char, ushort>(ref Unsafe.AsRef(in source)), offset + ((nuint)Vector128<byte>.Count / sizeof(ushort)));
-        var lower = Vector128.Min(v0, Vector128.Create((ushort)127));
-        var upper = Vector128.Min(v1, Vector128.Create((ushort)127));
 
         // prefer architecture specific intrinsic as they don't perform additional AND like Vector128.Narrow does
         if (Sse2.IsSupported)
         {
-            return Sse2.PackUnsignedSaturate(lower.AsInt16(), upper.AsInt16());
+            return Sse2.PackUnsignedSaturate(v0.AsInt16(), v1.AsInt16());
         }
         else if (AdvSimd.Arm64.IsSupported)
         {
-            return AdvSimd.Arm64.UnzipEven(lower.AsByte(), upper.AsByte());
+            return AdvSimd.Arm64.UnzipEven(v0.AsByte(), v1.AsByte());
         }
         else if (PackedSimd.IsSupported)
         {
-            return PackedSimd.ConvertNarrowingSaturateUnsigned(lower.AsInt16(), upper.AsInt16());
+            return PackedSimd.ConvertNarrowingSaturateUnsigned(v0.AsInt16(), v1.AsInt16());
         }
         else
         {
+            var lower = Vector128.Min(v0, Vector128.Create((ushort)127));
+            var upper = Vector128.Min(v1, Vector128.Create((ushort)127));
             return Vector128.Narrow(lower, upper);
         }
     }
@@ -269,8 +269,6 @@ internal readonly struct Vec256Char : ISimdVector<char, Vec256Char>
     {
         var v0 = Vector256.LoadUnsafe(ref Unsafe.As<char, ushort>(ref Unsafe.AsRef(in source)), offset);
         var v1 = Vector256.LoadUnsafe(ref Unsafe.As<char, ushort>(ref Unsafe.AsRef(in source)), offset + ((nuint)Vector256<byte>.Count / sizeof(ushort)));
-        var lower = Vector256.Min(v0, Vector256.Create((ushort)127));
-        var upper = Vector256.Min(v1, Vector256.Create((ushort)127));
 
         if (Avx2.IsSupported)
         {
@@ -278,11 +276,13 @@ internal readonly struct Vec256Char : ISimdVector<char, Vec256Char>
             // 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2
             // We want to swap the X and Y bits
             // 1, 1, 1, 1, 1, 1, 1, 1, X, X, X, X, X, X, X, X, Y, Y, Y, Y, Y, Y, Y, Y, 2, 2, 2, 2, 2, 2, 2, 2
-            var packed = Avx2.PackUnsignedSaturate(lower.AsInt16(), upper.AsInt16());
+            var packed = Avx2.PackUnsignedSaturate(v0.AsInt16(), v1.AsInt16());
             return Avx2.Permute4x64(packed.AsInt64(), 0b_11_01_10_00).AsByte();
         }
         else
         {
+            var lower = Vector256.Min(v0, Vector256.Create((ushort)127));
+            var upper = Vector256.Min(v1, Vector256.Create((ushort)127));
             return Vector256.Narrow(lower, upper);
         }
     }

--- a/FlameCsv.Core/Reading/Internal/ISimdVector.Generated.tt
+++ b/FlameCsv.Core/Reading/Internal/ISimdVector.Generated.tt
@@ -17,18 +17,20 @@
                                      // prefer architecture specific intrinsic as they don't perform additional AND like Vector128.Narrow does
                                      if (Sse2.IsSupported)
                                      {
-                                         return Sse2.PackUnsignedSaturate(lower.AsInt16(), upper.AsInt16());
+                                         return Sse2.PackUnsignedSaturate(v0.AsInt16(), v1.AsInt16());
                                      }
                                      else if (AdvSimd.Arm64.IsSupported)
                                      {
-                                         return AdvSimd.Arm64.UnzipEven(lower.AsByte(), upper.AsByte());
+                                         return AdvSimd.Arm64.UnzipEven(v0.AsByte(), v1.AsByte());
                                      }
                                      else if (PackedSimd.IsSupported)
                                      {
-                                         return PackedSimd.ConvertNarrowingSaturateUnsigned(lower.AsInt16(), upper.AsInt16());
+                                         return PackedSimd.ConvertNarrowingSaturateUnsigned(v0.AsInt16(), v1.AsInt16());
                                      }
                                      else
                                      {
+                                         var lower = Vector128.Min(v0, Vector128.Create((ushort)127));
+                                         var upper = Vector128.Min(v1, Vector128.Create((ushort)127));
                                          return Vector128.Narrow(lower, upper);
                                      }
                              """;
@@ -41,11 +43,13 @@
                                         // 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2
                                         // We want to swap the X and Y bits
                                         // 1, 1, 1, 1, 1, 1, 1, 1, X, X, X, X, X, X, X, X, Y, Y, Y, Y, Y, Y, Y, Y, 2, 2, 2, 2, 2, 2, 2, 2
-                                        var packed = Avx2.PackUnsignedSaturate(lower.AsInt16(), upper.AsInt16());
+                                        var packed = Avx2.PackUnsignedSaturate(v0.AsInt16(), v1.AsInt16());
                                         return Avx2.Permute4x64(packed.AsInt64(), 0b_11_01_10_00).AsByte();
                                     }
                                     else
                                     {
+                                        var lower = Vector256.Min(v0, Vector256.Create((ushort)127));
+                                        var upper = Vector256.Min(v1, Vector256.Create((ushort)127));
                                         return Vector256.Narrow(lower, upper);
                                     }
                             """;
@@ -255,8 +259,6 @@ internal readonly struct <#= typeName #> : ISimdVector<<#= keyword #>, <#= typeN
     {
         var v0 = Vector<#= size #>.LoadUnsafe(ref Unsafe.As<char, ushort>(ref Unsafe.AsRef(in source)), offset);
         var v1 = Vector<#= size #>.LoadUnsafe(ref Unsafe.As<char, ushort>(ref Unsafe.AsRef(in source)), offset + ((nuint)Vector<#= size #><byte>.Count / sizeof(ushort)));
-        var lower = Vector<#= size #>.Min(v0, Vector<#= size #>.Create((ushort)127));
-        var upper = Vector<#= size #>.Min(v1, Vector<#= size #>.Create((ushort)127));
 <#
                 WriteNarrowing(size);
 #>

--- a/FlameCsv.Tests/.runsettings
+++ b/FlameCsv.Tests/.runsettings
@@ -1,0 +1,20 @@
+﻿<RunSettings>
+    <RunConfiguration>
+        <EnvironmentVariables>
+            <!-- 128-bit vector operations -->
+<!--            <DOTNET_EnableSSE>0</DOTNET_EnableSSE>-->
+<!--            <DOTNET_EnableSSE2>0</DOTNET_EnableSSE2>-->
+<!--            <DOTNET_EnableSSE3>0</DOTNET_EnableSSE3>-->
+<!--            <DOTNET_EnableSSSE3>0</DOTNET_EnableSSSE3>-->
+<!--            <DOTNET_EnableSSE41>0</DOTNET_EnableSSE41>-->
+<!--            <DOTNET_EnableSSE42>0</DOTNET_EnableSSE42>-->
+
+            <!-- 256-bit vector operations -->
+<!--            <DOTNET_EnableAVX>0</DOTNET_EnableAVX>-->
+<!--            <DOTNET_EnableAVX2>0</DOTNET_EnableAVX2>-->
+
+            <!-- 512-bit vector operations -->
+<!--            <DOTNET_EnableAVX512F>0</DOTNET_EnableAVX512F>-->
+        </EnvironmentVariables>
+    </RunConfiguration>
+</RunSettings>

--- a/FlameCsv.Tests/Readers/UnescaperTests.cs
+++ b/FlameCsv.Tests/Readers/UnescaperTests.cs
@@ -39,7 +39,7 @@ public static class UnescaperTests
     [MemberData(nameof(UnescapeData))]
     public static void Should_Compress_Byte16(string input, string output)
     {
-        Assert.True(ByteSsse3Unescaper.IsSupported);
+        Assert.SkipUnless(ByteSsse3Unescaper.IsSupported, "ByteSsse3Unescaper is not supported on current hardware");
 
         byte[] data = Encoding.UTF8.GetBytes(input);
 
@@ -67,7 +67,7 @@ public static class UnescaperTests
     [MemberData(nameof(UnescapeData))]
     public static void Should_Compress_Byte32(string input, string output)
     {
-        Assert.True(ByteAvx2Unescaper.IsSupported);
+        Assert.SkipUnless(ByteAvx2Unescaper.IsSupported, "ByteAvx2Unescaper is not supported on current hardware");
 
         byte[] data = Encoding.UTF8.GetBytes(input);
 
@@ -95,7 +95,7 @@ public static class UnescaperTests
     [MemberData(nameof(UnescapeData))]
     public static void Should_Compress_Char8(string data, string output)
     {
-        Assert.True(CharAvxUnescaper.IsSupported);
+        Assert.SkipUnless(CharAvxUnescaper.IsSupported, "CharSse2Unescaper is not supported on current hardware");
 
         var quoteCount = data.AsSpan().Count('"');
         Assert.NotEqual(0, quoteCount);

--- a/FlameCsv.Tests/SimdVectorTests.cs
+++ b/FlameCsv.Tests/SimdVectorTests.cs
@@ -32,6 +32,8 @@ public static class SimdVectorTests
 
         static void Impl2<TVector>(char token) where TVector : struct, ISimdVector<char, TVector>
         {
+            Assert.SkipUnless(TVector.IsSupported, $"CPU support not available for {typeof(TVector).Name}");
+
             var data = new string(
                 Enumerable
                     .Range(0, (1024 * 8 / TVector.Count) + TVector.Count)
@@ -64,7 +66,7 @@ public static class SimdVectorTests
         where T : unmanaged, IBinaryInteger<T>
         where TVector : struct, ISimdVector<T, TVector>
     {
-        if (!TVector.IsSupported) return;
+        Assert.SkipUnless(TVector.IsSupported, $"CPU support not available for {typeof(TVector).Name}");
 
         var abcVec = TVector.LoadUnaligned(in data[0], 0);
         var aVec = TVector.Create(data[0]);

--- a/FlameCsv.Tests/Writing/VecEscapeTests.cs
+++ b/FlameCsv.Tests/Writing/VecEscapeTests.cs
@@ -39,6 +39,8 @@ public static class VecEscapeTests
     [MemberData(nameof(Data))]
     public static void Should_Escape_Char(string input, string expected)
     {
+        Assert.SkipUnless(Vec256Char.IsSupported, "Vec256Char is not supported on current hardware");
+
         Impl<char, SimdEscaperRFC<char, Vec256Char>, Vec256Char>(input, expected, in _cTokens);
     }
 
@@ -46,6 +48,8 @@ public static class VecEscapeTests
     [MemberData(nameof(Data))]
     public static void Should_Escape_Byte(string input, string expected)
     {
+        Assert.SkipUnless(Vec256Byte.IsSupported, "Vec256Byte is not supported on current hardware");
+
         Impl<byte, SimdEscaperRFC<byte, Vec256Byte>, Vec256Byte>(
             Encoding.UTF8.GetBytes(input),
             expected,


### PR DESCRIPTION
closes #40 